### PR TITLE
Add formatted value as an attribute on a node.

### DIFF
--- a/lib/node.dart
+++ b/lib/node.dart
@@ -85,6 +85,9 @@ class DgApiNode extends SimpleNode {
     }
 
     updateValue(new ValueUpdate(m['value'], ts: m['lastUpdate']));
+    if (m.containsKey('formatted')) {
+      attributes['@formatted'] = m['formatted'];
+    }
     valueReady = true;
   }
 


### PR DESCRIPTION
This will allow formatted values from DGApi to be accessed as an attribute on the node in question (currently the nodes show value but not the formatted value also supplied by the remote server).