### PR TITLE
Use last cookie for login

### DIFF
--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -60,8 +60,11 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
         return await loadString(uri, post, contentType, isAuthRelated, retries + 1);
       }
 
-      if (resp.headers["set-cookie"] != null)
-        addCookie(resp.headers["set-cookie"].last);
+      if (resp.headers["set-cookie"] != null) {
+        for (var cookie in resp.headers["set-cookie"]) {
+          addCookie(cookie);
+        }
+      }
 
       var data = await resp.transform(decoder).join();
       return data;

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -60,9 +60,7 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
         return await loadString(uri, post, contentType, isAuthRelated, retries + 1);
       }
 
-      if (resp.cookies.length > 0) {
-          serverCookies.addAll(resp.cookies);
-      }
+      serverCookies.addAll(resp.cookies);
 
       var data = await resp.transform(decoder).join();
       return data;

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -60,10 +60,8 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
         return await loadString(uri, post, contentType, isAuthRelated, retries + 1);
       }
 
-      if (resp.headers["set-cookie"] != null) {
-        for (var cookie in resp.headers["set-cookie"]) {
-          addCookie(cookie);
-        }
+      if (resp.cookies.length > 0) {
+          serverCookies.addAll(resp.cookies);
       }
 
       var data = await resp.transform(decoder).join();
@@ -111,7 +109,8 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
       return await loadBytes(uri, post, contentType);
     }
 
-    addCookie(resp.headers.value("set-cookie"));
+    serverCookies.addAll(resp.cookies);
+
     return resp.fold([], (a, b) {
       return a..addAll(b);
     });
@@ -124,20 +123,14 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
       req.headers.add("Authorization", "Basic ${authString}");
     }
 
-    if (serverCookie != null) {
-      req.headers.add("cookie", serverCookie);
+    if (serverCookies != null) {
+      req.cookies.addAll(serverCookies);
     }
     req.headers.add("Accept-Charset", "utf-8");
     req.headers.add("Accept-Encoding", "gzip, deflate");
   }
 
-  String serverCookie;
-
-  void addCookie(String cookie) {
-    if (cookie != null) {
-      serverCookie = cookie.split(";").where((str) => !str.toLowerCase().contains("path=")).join(";");
-    }
-  }
+  var serverCookies = new List<Cookie>();
 
   Future loginWithError() async {
     var result = await login();

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -60,7 +60,9 @@ class OldApiBaseAuthConnection implements IOldApiConnection {
         return await loadString(uri, post, contentType, isAuthRelated, retries + 1);
       }
 
-      addCookie(resp.headers.value("set-cookie"));
+      if (resp.headers["set-cookie"] != null)
+        addCookie(resp.headers["set-cookie"].last);
+
       var data = await resp.transform(decoder).join();
       return data;
     } catch (e, stack) {


### PR DESCRIPTION
A customer had an issue with multiple Set-Cookie headers being set from Niagara 4. This one uses the .last part of the "set-cookie" header if it's not null

There is probably a better way to get the "most recent" set-cookie, but this is tested with both AX and N4